### PR TITLE
Add build definitions service

### DIFF
--- a/vsts/build_definitions.go
+++ b/vsts/build_definitions.go
@@ -1,0 +1,44 @@
+package vsts
+
+import (
+	"fmt"
+)
+
+// BuildDefinitionsService handles communication with the build definitions methods on the API
+// utilising https://docs.microsoft.com/en-gb/rest/api/vsts/build/definitions
+type BuildDefinitionsService struct {
+	client *Client
+}
+
+// BuildDefinitionsListResponse describes the build definitions list response
+type BuildDefinitionsListResponse struct {
+	BuildDefinitions []BuildDefinition `json:"value"`
+	Count            int               `json:"count"`
+}
+
+// BuildDefinition represents a build definition in VSTS
+type BuildDefinition struct {
+	ID   int    `json:"id"`
+	Name string `json:"name"`
+}
+
+// BuildDefinitionsListOptions describes what the request to the API should look like
+type BuildDefinitionsListOptions struct {
+	Path string `url:"path,omitempty"`
+}
+
+// List returns a list of build definitions in VSTS
+// utilising https://docs.microsoft.com/en-gb/rest/api/vsts/build/definitions/list
+func (s *BuildDefinitionsService) List(opts *BuildDefinitionsListOptions) ([]BuildDefinition, error) {
+	URL := fmt.Sprintf("_apis/build/definitions?api-version=5.0-preview.6")
+	URL, err := addOptions(URL, opts)
+
+	request, err := s.client.NewRequest("GET", URL)
+	if err != nil {
+		return nil, err
+	}
+	var response BuildDefinitionsListResponse
+	_, err = s.client.Execute(request, &response)
+
+	return response.BuildDefinitions, err
+}

--- a/vsts/build_definitions_test.go
+++ b/vsts/build_definitions_test.go
@@ -1,0 +1,74 @@
+package vsts_test
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/benmatselby/go-vsts/vsts"
+)
+
+const (
+	buildDefinitionListURL      = "/VSTS_Project/_apis/build/definitions"
+	buildDefinitionListResponse = `{
+		"value": [
+			{
+				"id": 1,
+				"name": "build-death-star"
+			},
+			{
+				"id": 2,
+				"name": "build-ark"
+			}
+		],
+		"count": 2
+	}`
+)
+
+func TestBuildDefinitionsService_List(t *testing.T) {
+	tt := []struct {
+		name     string
+		URL      string
+		response string
+		count    int
+		index    int
+		defName  string
+		defId    int
+	}{
+		{name: "return two build definitions", URL: buildDefinitionListURL, response: buildDefinitionListResponse, count: 2, index: 0, defName: "build-death-star", defId: 1},
+		{name: "can handle no build definitions returned", URL: buildDefinitionListURL, response: "{}", count: 0, index: -1},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			c, mux, _, teardown := setup()
+			defer teardown()
+
+			mux.HandleFunc(tc.URL, func(w http.ResponseWriter, r *http.Request) {
+				testMethod(t, r, "GET")
+				json := tc.response
+				fmt.Fprint(w, json)
+			})
+
+			options := &vsts.BuildDefinitionsListOptions{}
+			buildDefs, err := c.BuildDefinitions.List(options)
+			if err != nil {
+				t.Fatalf("returned error: %v", err)
+			}
+
+			if tc.index > -1 {
+				if buildDefs[tc.index].ID != tc.defId {
+					t.Fatalf("expected build definition id %d, got %d", tc.defId, buildDefs[tc.index].ID)
+				}
+
+				if buildDefs[tc.index].Name != tc.defName {
+					t.Fatalf("expected build definition name %s, got %s", tc.defName, buildDefs[tc.index].Name)
+				}
+			}
+
+			if len(buildDefs) != tc.count {
+				t.Fatalf("expected length of build definitions to be %d; got %d", tc.count, len(buildDefs))
+			}
+		})
+	}
+}

--- a/vsts/builds.go
+++ b/vsts/builds.go
@@ -25,15 +25,18 @@ type Build struct {
 	Branch      string          `json:"sourceBranch"`
 }
 
-// BuildDefinition represents the `definition` aspect of the response
-type BuildDefinition struct {
-	Name string `json:"name"`
+// BuildsListOptions describes what the request to the API should look like
+type BuildsListOptions struct {
+	Definitions string `url:"definitions,omitempty"`
+	Branch      string `url:"branchName,omitempty"`
+	Count       int    `url:"$top,omitempty"`
 }
 
 // List returns list of the builds in VSTS
 // utilising https://docs.microsoft.com/en-gb/rest/api/vsts/build/builds/list
-func (s *BuildsService) List() ([]Build, error) {
+func (s *BuildsService) List(opts *BuildsListOptions) ([]Build, error) {
 	URL := fmt.Sprintf("/_apis/build/builds?api-version=4.1")
+	URL, err := addOptions(URL, opts)
 
 	request, err := s.client.NewRequest("GET", URL)
 	if err != nil {

--- a/vsts/builds_test.go
+++ b/vsts/builds_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"net/http"
 	"testing"
+
+	"github.com/benmatselby/go-vsts/vsts"
 )
 
 const (
@@ -54,7 +56,8 @@ func TestBuildsService_List(t *testing.T) {
 				fmt.Fprint(w, json)
 			})
 
-			builds, err := c.Builds.List()
+			options := &vsts.BuildsListOptions{}
+			builds, err := c.Builds.List(options)
 			if err != nil {
 				t.Fatalf("returned error: %v", err)
 			}

--- a/vsts/vsts.go
+++ b/vsts/vsts.go
@@ -28,12 +28,13 @@ type Client struct {
 	AuthToken string
 
 	// Services used to proxy to other API endpoints
-	Boards       *BoardsService
-	Builds       *BuildsService
-	Favourites   *FavouritesService
-	Iterations   *IterationsService
-	PullRequests *PullRequestsService
-	WorkItems    *WorkItemsService
+	Boards           *BoardsService
+	BuildDefinitions *BuildDefinitionsService
+	Builds           *BuildsService
+	Favourites       *FavouritesService
+	Iterations       *IterationsService
+	PullRequests     *PullRequestsService
+	WorkItems        *WorkItemsService
 }
 
 // NewClient gets the VSTS Client
@@ -46,6 +47,7 @@ func NewClient(account string, project string, token string) *Client {
 	c.BaseURL = fmt.Sprintf(baseURL, account)
 
 	c.Boards = &BoardsService{client: c}
+	c.BuildDefinitions = &BuildDefinitionsService{client: c}
 	c.Builds = &BuildsService{client: c}
 	c.Favourites = &FavouritesService{client: c}
 	c.Iterations = &IterationsService{client: c}


### PR DESCRIPTION
Add a build definitions service to the client.. This was built so I could get a list of build definitions for a team (Path=folder=team name), and from that request a list of builds based on the definitions within the team/folder/path